### PR TITLE
[WFCORE-2223] Drop pointless validation of jboss.modules.dir

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
@@ -364,8 +364,6 @@ public class HostControllerEnvironment extends ProcessEnvironment {
         File tmp = getFileFromProperty(MODULES_DIR);
         if (tmp == null) {
             tmp = new File(this.homeDir, "modules");
-        } else if (!tmp.exists() || !tmp.isDirectory()) {
-            throw HostControllerLogger.ROOT_LOGGER.modulesDirectoryDoesNotExist(tmp);
         }
         this.modulesDir = tmp;
         @SuppressWarnings("deprecation")

--- a/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
@@ -931,8 +931,9 @@ public interface HostControllerLogger extends BasicLogger {
     @Message(id = 95, value = "Home directory does not exist: %s")
     IllegalStateException homeDirectoryDoesNotExist(File f);
 
-    @Message(id = 96, value = "Determined modules directory does not exist: %s")
-    IllegalStateException modulesDirectoryDoesNotExist(File f);
+    // WFCORE-2223 no longer used
+//    @Message(id = 96, value = "Determined modules directory does not exist: %s")
+//    IllegalStateException modulesDirectoryDoesNotExist(File f);
 
     @Message(id = 97, value = "Domain base directory does not exist: %s")
     IllegalStateException domainBaseDirectoryDoesNotExist(File f);

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -414,8 +414,6 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
             File tmp = getFileFromProperty(MODULES_DIR, props);
             if (tmp == null) {
                 tmp = new File(homeDir, "modules");
-            } else if (!tmp.exists() || !tmp.isDirectory()) {
-                throw ServerLogger.ROOT_LOGGER.modulesDirectoryDoesNotExist(tmp);
             }
             modulesDir = tmp;
 

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -762,8 +762,9 @@ public interface ServerLogger extends BasicLogger {
     @Message(id = 117, value = "Unable to initialise a basic SSLContext '%s'")
     IllegalStateException unableToInitialiseSSLContext(String message);
 
-    @Message(id = 118, value = "Determined modules directory does not exist: %s")
-    IllegalStateException modulesDirectoryDoesNotExist(File f);
+    // WFCORE-2223 no longer used
+//    @Message(id = 118, value = "Determined modules directory does not exist: %s")
+//    IllegalStateException modulesDirectoryDoesNotExist(File f);
 
     @Message(id = 119, value = "Home directory does not exist: %s")
     IllegalStateException homeDirectoryDoesNotExist(File f);


### PR DESCRIPTION
This fixes [WFCORE-2223 Setting JBOSS_MODULEPATH is lost for second start of embed-server](https://issues.redhat.com/browse/WFCORE-2223).

Description
When embed-server command is used more times in the CLI and a custom JBOSS_MODULEPATH is configured, then only the first server start uses the correct module path. The subsequent `embed-server` call results in error:
```
Cannot start embedded server: WFLYEMB0022: Cannot invoke 'start' on embedded process: WFLYSRV0118: Determined modules directory does not exist
```

Note 
This is needed, because CLI scripts are used in WildFly integration tests to restore some missing bits of configuration removed by hardening.