### PR TITLE
upgrade xalan to 2.7.1.redhat-00013

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.19.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.10.1.Final</version.org.wildfly.security.elytron-web>
-        <version.xalan>2.7.1.jbossorg-2</version.xalan>
+        <version.xalan>2.7.1.redhat-00013</version.xalan>
 
         <!-- Allow insecure repositories -->
         <insecure.repositories>WARN</insecure.repositories>


### PR DESCRIPTION
PJFCB-2365 CVE-2022-34169 WildFly 21, The Apache Xalan Java XSLT library is vulnerable to an integer truncation issue when processing malicious XSLT stylesheets