### PR TITLE
PJFCB-2439 Suppression for CVE-2022-2053 WildFly 26

### DIFF
--- a/owasp-suppression.xml
+++ b/owasp-suppression.xml
@@ -123,5 +123,23 @@
        <cpe>cpe:/a:apache:log4j</cpe>
 	   <vulnerabilityName>CVE-2022-33915</vulnerabilityName>
     </suppress>
-	
+
+    <!--undertow 2.2.19.Final fixed CVE-2022-2053  based on https://bugzilla.redhat.com/show_bug.cgi?id=2095862-->
+    <suppress>
+        <notes><![CDATA[
+   file name: undertow-core-2.2.19.Final.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.undertow/undertow\-core@.*$</packageUrl>
+        <vulnerabilityName>CVE-2022-2053</vulnerabilityName>
+    </suppress>
+
+    <!-- undertow server uses undertow-core, so it also has fixed CVE-2022-2053 when using undertow-core-2.2.19.Final-->
+    <suppress>
+        <notes><![CDATA[
+   file name: undertow-server-1.10.1.Final.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.wildfly\.security\.elytron\-web/undertow\-server@.*$</packageUrl>
+        <cve>CVE-2022-2053</cve>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
undertow 2.2.19.Final fixed CVE-2022-2053  based on https://bugzilla.redhat.com/show_bug.cgi?id=2095862
undertow server uses undertow-core, so it also has fixed CVE-2022-2053 when using undertow-core-2.2.19.Final
