### PR TITLE
Adding suppression for CVE-2021-3859 which seems to be false-positive…

### DIFF
--- a/owasp-suppression.xml
+++ b/owasp-suppression.xml
@@ -226,4 +226,14 @@
         <cve>CVE-2020-10687</cve>
         <cve>CVE-2021-20220</cve>
     </suppress>
+
+    <!--    This seems to be false positive. The issue was checked already in https://jira-bld-ppl.psi.de/browse/PJFCB-1001 and Undertow
+    version in WF21 is 2.2.19 and according to UNDERTOW-1979 2.2.15 is already free of this problem.-->
+    <suppress>
+        <notes><![CDATA[
+   file name: undertow-server-1.10.1.Final.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.wildfly\.security\.elytron\-web/undertow\-server@.*$</packageUrl>
+        <cve>CVE-2021-3859</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
…. We've already using Undertow 2.2.19 (error is not present in Underteo 2.2.15). Also scanner is recognizing error in undertow-server jar which is part of Undertow-Elytron integration module and has nothing to do with the subject of vulnerability.