### PR TITLE
Fix for PJFCB-2533 in WF21

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/RespawnHttpTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/RespawnHttpTestCase.java
@@ -665,7 +665,7 @@ public class RespawnHttpTestCase {
 
         abstract String getJavaCommand();
 
-        abstract String getKillCommand(RunningProcess process);
+        abstract String[] getKillCommand(RunningProcess process);
 
         private boolean containsProcesses(List<RunningProcess> runningProcesses, String...names){
             for (String name : names){
@@ -725,8 +725,8 @@ public class RespawnHttpTestCase {
         }
 
         @Override
-        String getKillCommand(RunningProcess process) {
-            return "kill -9 " + process.getProcessId();
+        String[] getKillCommand(RunningProcess process) {
+            return new String[] {"bash", "-l", "-c", "kill -9 " + process.getProcessId()};
         }
     }
 
@@ -750,8 +750,8 @@ public class RespawnHttpTestCase {
         }
 
         @Override
-        String getKillCommand(RunningProcess process) {
-            return "taskkill /f /pid " + process.getProcessId();
+        String[] getKillCommand(RunningProcess process) {
+            return new String[] {"taskkill", "/f", "/pid", process.getProcessId()};
         }
     }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/RespawnTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/RespawnTestCase.java
@@ -685,7 +685,7 @@ public class RespawnTestCase {
 
         abstract String getJavaCommand();
 
-        abstract String getKillCommand(RunningProcess process);
+        abstract String[] getKillCommand(RunningProcess process);
 
         private boolean containsProcesses(List<RunningProcess> runningProcesses, String...names){
             for (String name : names){
@@ -745,8 +745,8 @@ public class RespawnTestCase {
         }
 
         @Override
-        String getKillCommand(RunningProcess process) {
-            return "kill -9 " + process.getProcessId();
+        String[] getKillCommand(RunningProcess process) {
+            return new String[] {"bash", "-l", "-c", "kill -9 " + process.getProcessId()};
         }
     }
 
@@ -770,8 +770,8 @@ public class RespawnTestCase {
         }
 
         @Override
-        String getKillCommand(RunningProcess process) {
-            return "taskkill /f /pid " + process.getProcessId();
+        String[] getKillCommand(RunningProcess process) {
+            return new String[] {"taskkill", "/f", "/pid", process.getProcessId()};
         }
     }
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/suspend/SuspendOnSoftKillTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/suspend/SuspendOnSoftKillTestCase.java
@@ -341,7 +341,7 @@ public class SuspendOnSoftKillTestCase {
 
         abstract String[] getJpsCommand();
 
-        abstract String getSoftKillCommand(RunningProcess process);
+        abstract String[] getSoftKillCommand(RunningProcess process);
     }
 
     private static class UnixProcessUtil extends ProcessUtil {
@@ -362,8 +362,8 @@ public class SuspendOnSoftKillTestCase {
         }
 
         @Override
-        String getSoftKillCommand(RunningProcess process) {
-            return "kill -15 " + process.getProcessId();
+        String[] getSoftKillCommand(RunningProcess process) {
+            return new String[] {"bash", "-l", "-c", "kill -15 " + process.getProcessId()};
         }
     }
 
@@ -382,8 +382,8 @@ public class SuspendOnSoftKillTestCase {
         }
 
         @Override
-        String getSoftKillCommand(RunningProcess process) {
-            return "taskkill /pid " + process.getProcessId();
+        String[] getSoftKillCommand(RunningProcess process) {
+            return new String[] {"taskkill", "/pid", process.getProcessId()};
         }
     }
 


### PR DESCRIPTION
After update of Jenkins agent, tests that were invoking "kill -9" command stopped to working with 'Cannot run program "kill": error=2, No such file or directory' error message. By direct wrapping kill execution with a shell we should avoid this problem that was proven on the local image with Jenkins agent.