### PR TITLE
Bugfix/pjfcb 3850 admin only policy test case wf core 21

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyPolicyTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyPolicyTestCase.java
@@ -37,6 +37,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeoutException;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
@@ -47,6 +48,7 @@ import org.jboss.as.host.controller.model.host.AdminOnlyDomainConfigPolicy;
 import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
 import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
 import org.jboss.as.test.integration.domain.management.util.WildFlyManagedConfiguration;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.junit.After;
@@ -67,6 +69,8 @@ public class AdminOnlyPolicyTestCase {
 
     private static final long initTime = System.currentTimeMillis();
     private static int slaveCount;
+
+    private static int exitCodeTimeout = TimeoutUtil.adjust(5);
 
     @BeforeClass
     public static void setupDomain() throws Exception {
@@ -149,12 +153,12 @@ public class AdminOnlyPolicyTestCase {
     }
 
     @Test
-    public void testFetchFromMasterWithoutDiscovery() throws URISyntaxException {
+    public void testFetchFromMasterWithoutDiscovery() throws URISyntaxException, InterruptedException, TimeoutException {
         try {
             createSecondSlave(AdminOnlyDomainConfigPolicy.FETCH_FROM_MASTER, false, false);
             Assert.fail("secondSlaveLifecyleUtil should not have started");
         } catch (RuntimeException e) {
-            Assert.assertTrue(domainSlaveLifecycleUtil.getProcessExitCode() >= 0);
+            Assert.assertTrue(domainSlaveLifecycleUtil.awaitForProcessExitCode(exitCodeTimeout) >= 0);
         }
     }
 
@@ -165,22 +169,22 @@ public class AdminOnlyPolicyTestCase {
     }
 
     @Test
-    public void testRequireLocalConfigWithDiscovery() throws URISyntaxException {
+    public void testRequireLocalConfigWithDiscovery() throws URISyntaxException, InterruptedException, TimeoutException {
         try {
             createSecondSlave(AdminOnlyDomainConfigPolicy.REQUIRE_LOCAL_CONFIG, true, false);
             Assert.fail("secondSlaveLifecyleUtil should not have started");
         } catch (RuntimeException e) {
-            Assert.assertTrue(domainSlaveLifecycleUtil.getProcessExitCode() >= 0);
+            Assert.assertTrue(domainSlaveLifecycleUtil.awaitForProcessExitCode(exitCodeTimeout) >= 0);
         }
     }
 
     @Test
-    public void testRequireLocalConfigWithoutDiscovery() throws URISyntaxException {
+    public void testRequireLocalConfigWithoutDiscovery() throws URISyntaxException, InterruptedException, TimeoutException {
         try {
             createSecondSlave(AdminOnlyDomainConfigPolicy.REQUIRE_LOCAL_CONFIG, false, false);
             Assert.fail("secondSlaveLifecyleUtil should not have started");
         } catch (RuntimeException e) {
-            Assert.assertTrue(domainSlaveLifecycleUtil.getProcessExitCode() >= 0);
+            Assert.assertTrue(domainSlaveLifecycleUtil.awaitForProcessExitCode(exitCodeTimeout) >= 0);
         }
     }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyPolicyTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyPolicyTestCase.java
@@ -55,13 +55,13 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-//import org.junit.Ignore;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * Tests of running domain hosts in admin-only move.
  */
-//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+@Ignore("https://issues.redhat.com/browse/WFCORE-6032")
 public class AdminOnlyPolicyTestCase {
 
     private static DomainTestSupport testSupport;
@@ -124,12 +124,6 @@ public class AdminOnlyPolicyTestCase {
         executeForResult(domainSlaveLifecycleUtil.getDomainClient(), op);
         // This should have pulled down the 'other' profile
         validateProfiles("default", "other");
-
-//        ModelNode remove = Util.createRemoveOperation(pa);
-//        executeForResult(domainSlaveLifecycleUtil.getDomainClient(), remove);
-//
-//        // This should have pulled down the 'other' profile
-//        validateProfiles("default");
     }
 
     @Test
@@ -144,12 +138,6 @@ public class AdminOnlyPolicyTestCase {
         executeForResult(domainSlaveLifecycleUtil.getDomainClient(), op);
         // This should have pulled down the 'other' profile
         validateProfiles("default", "other");
-
-//        ModelNode remove = Util.createRemoveOperation(pa);
-//        executeForResult(domainSlaveLifecycleUtil.getDomainClient(), remove);
-//
-//        // This should have pulled down the 'other' profile
-//        validateProfiles("default");
     }
 
     @Test

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainLifecycleUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainLifecycleUtil.java
@@ -323,6 +323,30 @@ public class DomainLifecycleUtil implements AutoCloseable {
     }
 
     /**
+     * Poll until {@link #getProcessExitCode()} returns 0 or a positive value or the
+     * timeout passes as argument is reached.
+     *
+     * @param timeOutInSeconds timeout in seconds to wait for getting exit value.
+     *
+     * @throws TimeoutException if the timeout is up.
+     * @throws InterruptedException if interrupted while sleeping.
+     */
+    public int awaitForProcessExitCode(int timeOutInSeconds) throws TimeoutException, InterruptedException {
+        long deadline = System.currentTimeMillis() +  timeOutInSeconds * 1000;
+        int exitValue = getProcessExitCode();
+        while (exitValue < 0) {
+            long remaining = deadline - System.currentTimeMillis();
+            if(remaining <= 0) {
+               throw new TimeoutException(String.format("Could not get the process exit code within [%d] seconds", timeOutInSeconds));
+            }
+            TimeUnit.MILLISECONDS.sleep(250);
+            exitValue = getProcessExitCode();
+        }
+
+        return exitValue;
+    }
+
+    /**
      * Stop and wait for the process to exit.
      */
     public synchronized void stop() {


### PR DESCRIPTION
AdminOnlyPolicyTestCase sometimes stucks stopping the entire pipeline and because it's not from our changes (links below) I cherry picked commit from the main wildfly repo ignoring this test class.
I also cherry picked 'WFCORE-5978' commit which adds timeout to 3 of 10 tests (small improve) in case we could unignore AdminOnlyPolicyTestCase 

https://issues.redhat.com/browse/WFCORE-6032
https://issues.redhat.com/browse/JBEAP-24063

https://jenkins3.comdev.psi.de/job/WCC/job/wf-custom-branch-build-and-test-pipeline/200/
