### PR TITLE
PJFCB-4628 Merge workaround from WFCORE-5922

### DIFF
--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingLegacySubsystemTestCase.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingLegacySubsystemTestCase.java
@@ -68,6 +68,7 @@ import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceNotFoundException;
 import org.jboss.msc.service.ServiceTarget;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.wildfly.extension.io.IOServices;
 import org.wildfly.extension.io.WorkerService;
@@ -189,6 +190,7 @@ public class RemotingLegacySubsystemTestCase extends AbstractRemotingSubsystemBa
     }
 
     @Test
+    @Ignore("https://issues.redhat.com/browse/WFCORE-5386")
     public void testSubsystemWithConnectorPropertyChange() throws Exception {
         KernelServices services = createKernelServicesBuilder(createRuntimeAdditionalInitialization(false))
                 .setSubsystemXmlResource("remoting-with-connector.xml")


### PR DESCRIPTION
Ignore RemotingLegacySubsystemTestCase#testSubsystemWithConnectorPropertyChange